### PR TITLE
Add AutoFlow environment setup example

### DIFF
--- a/AutoFlow/README.md
+++ b/AutoFlow/README.md
@@ -1,0 +1,14 @@
+# AutoFlow Setup
+
+This folder contains a simple Python script, `autoflow_setup.py`, that illustrates one way to automate the environment setup for the feedback package generated in earlier steps.
+
+The script follows the basic flow described in your instructions:
+
+1. **Start Codex Env** – logged when the script begins.
+2. **Check ENV + Secrets** – verifies that the environment variable `API_KEY` is present. If not, it exits with an error.
+3. **Run Setup Script** – extracts `/mnt/data/autoflow_feedback_package.zip` into `/mnt/data/autoflow_feedback_package`.
+4. **Log Monitor** – simulates monitoring and records progress in `autoflow_setup.log`.
+5. **Error Handling / Auto-Fix** – if monitoring raises an exception, the script logs the issue, attempts a placeholder auto-fix, and restarts the monitor step.
+6. **Success & Logging** – on completion, the log file notes success and the script exits.
+
+This is a minimal example; you can modify it to integrate real setup tasks, logging, or error handling as needed.

--- a/AutoFlow/autoflow_setup.py
+++ b/AutoFlow/autoflow_setup.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import os
+import zipfile
+import logging
+import time
+
+LOG_FILE = 'autoflow_setup.log'
+ZIP_PATH = '/mnt/data/autoflow_feedback_package.zip'
+DEST_DIR = '/mnt/data/autoflow_feedback_package'
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()]
+)
+
+
+def check_env():
+    """Ensure required environment variables are present."""
+    required_vars = ['API_KEY']
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        logging.error('Missing environment variables: %s', ', '.join(missing))
+        return False
+    logging.info('All required environment variables present')
+    return True
+
+
+def run_setup():
+    """Extract the feedback package archive."""
+    logging.info('Running setup script...')
+    if not os.path.exists(ZIP_PATH):
+        logging.error('Zip file not found at %s', ZIP_PATH)
+        return False
+    os.makedirs(DEST_DIR, exist_ok=True)
+    with zipfile.ZipFile(ZIP_PATH, 'r') as zipf:
+        zipf.extractall(DEST_DIR)
+    logging.info('Extracted archive to %s', DEST_DIR)
+    return True
+
+
+def monitor():
+    """Mock log monitoring step."""
+    logging.info('Starting log monitor...')
+    time.sleep(1)
+    logging.info('Setup complete')
+
+
+def main():
+    logging.info('--- Start Codex Env ---')
+    if not check_env():
+        logging.error('Environment check failed. Halting.')
+        return
+    if not run_setup():
+        logging.error('Setup script failed.')
+        return
+    try:
+        monitor()
+    except Exception as e:
+        logging.error('Error during monitoring: %s', e)
+        logging.info('Attempting auto-fix...')
+        # Placeholder for auto-fix logic
+        time.sleep(1)
+        logging.info('Restarting...')
+        monitor()
+    logging.info('Success')
+    logging.info('Log archived at %s', LOG_FILE)
+    logging.info('Notify complete')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `AutoFlow` folder with a Python script `autoflow_setup.py`
- include a README explaining the example workflow

## Testing
- `python3 -m py_compile AutoFlow/autoflow_setup.py`


------
https://chatgpt.com/codex/tasks/task_b_686350af5d308328929a02ac7e7f8e54