### PR TITLE
Add ghostframe tasks utilities

### DIFF
--- a/ghostframe-tasks/README.md
+++ b/ghostframe-tasks/README.md
@@ -1,0 +1,26 @@
+# Ghostframe Tasks
+
+Utility scripts for managing prompt templates and issue synchronization.
+
+## Scripts
+
+- **`convert_txt_to_json.py`** – Scan a directory for `.txt` files and produce a JSON file containing the filename and text content for each.
+- **`validate_templates.py`** – Validate prompt templates (.json or .txt) ensuring required fields are present and any API keys are placeholders.
+- **`sync_linear_issues.py`** – Example stub showing how repo issues might be synced to Linear. Requires `LINEAR_API_KEY` environment variable.
+
+## Basic Usage
+
+```bash
+# convert all txt files in ./prompts to templates.json
+python convert_txt_to_json.py ./prompts templates.json
+
+# validate templates in ./prompts
+python validate_templates.py ./prompts
+
+# sync issues (stub)
+LINEAR_API_KEY=your_token python sync_linear_issues.py
+```
+
+## deploy_checkpoints.json
+
+This JSON file can be used to record commit hashes or other data for deployment checkpoints and validation status.

--- a/ghostframe-tasks/convert_txt_to_json.py
+++ b/ghostframe-tasks/convert_txt_to_json.py
@@ -1,0 +1,25 @@
+import argparse
+import json
+from pathlib import Path
+
+
+def convert_txt_files(input_dir: Path, output_file: Path) -> None:
+    entries = []
+    for txt_path in input_dir.rglob('*.txt'):
+        with txt_path.open('r', encoding='utf-8') as f:
+            content = f.read()
+        entries.append({'filename': str(txt_path.relative_to(input_dir)), 'text': content})
+    with output_file.open('w', encoding='utf-8') as f:
+        json.dump(entries, f, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Convert .txt prompt files to JSON list.')
+    parser.add_argument('input_dir', type=Path, help='Directory to search for .txt files')
+    parser.add_argument('output', type=Path, help='Path to write JSON output')
+    args = parser.parse_args()
+    convert_txt_files(args.input_dir, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/ghostframe-tasks/deploy_checkpoints.json
+++ b/ghostframe-tasks/deploy_checkpoints.json
@@ -1,0 +1,3 @@
+{
+  "checkpoints": []
+}

--- a/ghostframe-tasks/sync_linear_issues.py
+++ b/ghostframe-tasks/sync_linear_issues.py
@@ -1,0 +1,33 @@
+"""Stub script to sync GitHub issues to Linear.
+
+Requires LINEAR_API_KEY environment variable and optionally GITHUB_TOKEN.
+"""
+import os
+import requests
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+
+
+def create_linear_issue(title: str, description: str) -> None:
+    token = os.environ.get("LINEAR_API_KEY")
+    if not token:
+        raise RuntimeError("LINEAR_API_KEY not set")
+    headers = {"Authorization": token, "Content-Type": "application/json"}
+    query = {
+        "query": "mutation IssueCreate($input: IssueCreateInput!) { issueCreate(input: $input) { success } }",
+        "variables": {"input": {"title": title, "description": description}}
+    }
+    response = requests.post(LINEAR_API_URL, json=query, headers=headers)
+    if response.status_code != 200:
+        raise RuntimeError(f"Linear API error: {response.text}")
+
+
+# Placeholder: fetch repo issues and call create_linear_issue for each.
+# Actual implementation would use the GitHub API.
+
+def main() -> None:
+    print("Stub for syncing issues. Implement GitHub issue retrieval and mapping to Linear here.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ghostframe-tasks/validate_templates.py
+++ b/ghostframe-tasks/validate_templates.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import List
+
+API_KEY_PATTERN = re.compile(r'(?:sk-\w{10,}|api_key\s*[:=]\s*\S+)', re.IGNORECASE)
+
+
+def validate_json(path: Path, errors: List[str]) -> None:
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except json.JSONDecodeError as e:
+        errors.append(f"{path}: invalid JSON - {e}")
+        return
+    if 'prompt' not in data:
+        errors.append(f"{path}: missing 'prompt' field")
+    if 'tools' in data and not isinstance(data['tools'], list):
+        errors.append(f"{path}: 'tools' should be a list")
+    if API_KEY_PATTERN.search(json.dumps(data)):
+        errors.append(f"{path}: possible API key present; use placeholder")
+
+
+def validate_text(path: Path, errors: List[str]) -> None:
+    text = path.read_text(encoding='utf-8')
+    if API_KEY_PATTERN.search(text):
+        errors.append(f"{path}: possible API key present; use placeholder")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Validate prompt templates.')
+    parser.add_argument('directory', type=Path, help='Directory of templates to check')
+    args = parser.parse_args()
+
+    errors: List[str] = []
+    for file in args.directory.rglob('*'):
+        if file.name == 'deploy_checkpoints.json':
+            continue
+        if file.suffix == '.json':
+            validate_json(file, errors)
+        elif file.suffix == '.txt':
+            validate_text(file, errors)
+    if errors:
+        print('\n'.join(errors))
+        exit(1)
+    print('All templates valid.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `convert_txt_to_json.py` to build JSON collections from text prompts
- add `validate_templates.py` to check schema and API keys
- add a stub `sync_linear_issues.py` for Linear integration
- document usage in `ghostframe-tasks/README.md`
- track milestone data with `deploy_checkpoints.json`

## Testing
- `python -m py_compile ghostframe-tasks/*.py`
- `python ghostframe-tasks/validate_templates.py ghostframe-tasks`


------
https://chatgpt.com/codex/tasks/task_b_6864a3d0759c8328a1f1d4630a3e5d90