### PR TITLE
Fix recursive validation and extend tests

### DIFF
--- a/ghostframe-tasks/README.md
+++ b/ghostframe-tasks/README.md
@@ -5,7 +5,9 @@ Utility scripts for managing prompt templates and issue synchronization.
 ## Scripts
 
 - **`convert_txt_to_json.py`** – Scan a directory for `.txt` files and produce a JSON file containing the filename and text content for each.
-- **`validate_templates.py`** – Validate prompt templates (.json or .txt) ensuring required fields are present and any API keys are placeholders.
+- **`validate_templates.py`** – Validate prompt templates (.json or .txt) ensuring
+  required fields are present and any API keys are placeholders. The script
+  searches directories recursively.
 - **`sync_linear_issues.py`** – Example stub showing how repo issues might be synced to Linear. Requires `LINEAR_API_KEY` environment variable.
 
 ## Basic Usage
@@ -14,7 +16,7 @@ Utility scripts for managing prompt templates and issue synchronization.
 # convert all txt files in ./prompts to templates.json
 python convert_txt_to_json.py ./prompts templates.json
 
-# validate templates in ./prompts
+# validate templates in ./prompts (recurses into subdirectories)
 python validate_templates.py ./prompts
 
 # sync issues (stub)

--- a/ghostframe_tasks/validate_templates.py
+++ b/ghostframe_tasks/validate_templates.py
@@ -40,6 +40,7 @@ def validate_file(json_path: Path) -> None:
 
 
 def validate_directory(directory: Path) -> None:
+    """Validate all JSON templates in *directory* recursively."""
     directory = Path(directory)
-    for json_file in directory.glob('*.json'):
+    for json_file in directory.rglob('*.json'):
         validate_file(json_file)

--- a/tests/test_validate_templates.py
+++ b/tests/test_validate_templates.py
@@ -29,3 +29,22 @@ def test_missing_api_key(tmp_path):
         del os.environ[validate_templates.API_KEY_ENV]
     with pytest.raises(validate_templates.MissingAPIKeyError):
         validate_templates.check_api_key()
+
+
+def test_validate_directory_recursive_success(tmp_path):
+    data = {"title": "t", "prompt": "p"}
+    subdir = tmp_path / "sub" / "inner"
+    subdir.mkdir(parents=True)
+    json_file = subdir / "tpl.json"
+    json_file.write_text(json.dumps(data))
+    validate_templates.validate_directory(tmp_path)
+
+
+def test_validate_directory_recursive_failure(tmp_path):
+    data = {"title": "t"}
+    subdir = tmp_path / "a" / "b"
+    subdir.mkdir(parents=True)
+    json_file = subdir / "tpl.json"
+    json_file.write_text(json.dumps(data))
+    with pytest.raises(validate_templates.InvalidTemplateError):
+        validate_templates.validate_directory(tmp_path)


### PR DESCRIPTION
## Summary
- update `validate_directory` to search subfolders recursively
- document recursion in ghostframe-tasks README

## Testing
- `pip install jsonschema`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6864d61791508328953ab3c98bfa3b31